### PR TITLE
aws/create-eck/license: fix set command

### DIFF
--- a/aws/create-eck/license/1ClickAddLicense.sh
+++ b/aws/create-eck/license/1ClickAddLicense.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
--e
+set -e
 
 echo "appling enterprise trial license"
 # initialize terraform configuration


### PR DESCRIPTION
"set" command appears to be missing?