### PR TITLE
Add missing project parameter to GCP GKE setkubectl.sh script

### DIFF
--- a/gcp/gke/outputs.tf
+++ b/gcp/gke/outputs.tf
@@ -2,6 +2,10 @@ output "cluster_name" {
   value = google_container_cluster.k8s.name
 }
 
+output "gcp_project" {
+  value = google_container_cluster.k8s.project
+}
+
 output "region" {
   value = google_container_cluster.k8s.location
 }

--- a/gcp/gke/setkubectl.sh
+++ b/gcp/gke/setkubectl.sh
@@ -5,7 +5,10 @@ clusternameraw=$(terraform output cluster_name)
 clustername=${clusternameraw//\"/}
 regionraw=$(terraform output region)
 region=${regionraw//\"/}
+projectraw=$(terraform output gcp_project)
+projectraw=${projectraw//\"/}
 echo $clustername
 echo $region
-gcloud container clusters get-credentials $clustername --region=$region
+echo $project
+gcloud container clusters get-credentials $clustername --region=$region --project=$project
 echo "setkubectl.sh: finished setting local kubectl"


### PR DESCRIPTION
When this project parameter isn't provided in a gcloud command, gcloud will use the user's default project, which may not be the project they want to modify here. This could lead the command to fail since it can't find the cluster credentials in the other project, or worse, modifying the wrong cluster in another project.