### PR TITLE
the domain name for the tls cert was incorect on the gcp build. fixed it

### DIFF
--- a/gcp/eck/eck-yamls/es.yaml
+++ b/gcp/eck/eck-yamls/es.yaml
@@ -471,4 +471,4 @@ spec:
    tls:
     selfSignedCertificate:
      subjectAltNames:
-     - dns: "*.cloudapp.azure.com"
+     - dns: "*.googleusercontent.com"


### PR DESCRIPTION
Changed from azure to gcp domain name 